### PR TITLE
refactor: move response header away from request

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,24 @@
+package webkit
+
+import (
+	"context"
+	"net/http"
+)
+
+type contextKey int
+
+const (
+	_ contextKey = iota
+	ctxKeyHTTPResponseWriter
+)
+
+// ResponseHeaderFromCtx returns Header for HTTP response which will be sent.
+// It returns nil if it doesn't exist.
+func ResponseHeaderFromCtx(ctx context.Context) http.Header {
+	w, ok := ctx.Value(ctxKeyHTTPResponseWriter).(http.ResponseWriter)
+	if ok {
+		return w.Header()
+	}
+
+	return nil
+}

--- a/context.go
+++ b/context.go
@@ -13,7 +13,7 @@ const (
 )
 
 // ResponseHeaderFromCtx returns Header for HTTP response which will be sent.
-// It returns nil if it doesn't exist.
+// The function returns a nil map if the Header doesn't exist.
 func ResponseHeaderFromCtx(ctx context.Context) http.Header {
 	w, ok := ctx.Value(ctxKeyHTTPResponseWriter).(http.ResponseWriter)
 	if ok {

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,19 @@
+package webkit
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResponseHeaderFromCtx(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ctx := context.WithValue(context.Background(), ctxKeyHTTPResponseWriter, rr)
+	require.NotNil(t, ResponseHeaderFromCtx(ctx))
+}
+
+func Test_ResponseHeaderFromCtx_nil(t *testing.T) {
+	require.Nil(t, ResponseHeaderFromCtx(context.Background()))
+}

--- a/cors.go
+++ b/cors.go
@@ -33,36 +33,37 @@ func WithCORS(cfg CORSConfig) Middleware {
 			httpReq := req.HTTPRequest()
 			origin := httpReq.Header.Get(HeaderOrigin)
 			allowOrigin := getAllowOrigin(origin, cfg)
+			header := ResponseHeaderFromCtx(ctx)
 
 			// non-OPTIONS requests
 			if httpReq.Method != http.MethodOptions {
-				req.ResponseHeader().Add(HeaderVary, HeaderOrigin)
-				req.ResponseHeader().Set(HeaderAccessControlAllowOrigin, allowOrigin)
+				header.Add(HeaderVary, HeaderOrigin)
+				header.Set(HeaderAccessControlAllowOrigin, allowOrigin)
 				if cfg.AllowCredentials {
-					req.ResponseHeader().Set(HeaderAccessControlAllowCredentials, "true")
+					header.Set(HeaderAccessControlAllowCredentials, "true")
 				}
 				return next(ctx, req)
 			}
 
 			// Preflight requests
-			req.ResponseHeader().Add(HeaderVary, HeaderOrigin)
-			req.ResponseHeader().Add(HeaderVary, HeaderAccessControlRequestMethod)
-			req.ResponseHeader().Add(HeaderVary, HeaderAccessControlRequestHeaders)
-			req.ResponseHeader().Set(HeaderAccessControlAllowOrigin, allowOrigin)
-			req.ResponseHeader().Set(HeaderAccessControlAllowMethods, allowMethods)
+			header.Add(HeaderVary, HeaderOrigin)
+			header.Add(HeaderVary, HeaderAccessControlRequestMethod)
+			header.Add(HeaderVary, HeaderAccessControlRequestHeaders)
+			header.Set(HeaderAccessControlAllowOrigin, allowOrigin)
+			header.Set(HeaderAccessControlAllowMethods, allowMethods)
 			if cfg.AllowCredentials {
-				req.ResponseHeader().Set(HeaderAccessControlAllowCredentials, "true")
+				header.Set(HeaderAccessControlAllowCredentials, "true")
 			}
 			if allowHeaders != "" {
-				req.ResponseHeader().Set(HeaderAccessControlAllowHeaders, allowHeaders)
+				header.Set(HeaderAccessControlAllowHeaders, allowHeaders)
 			} else {
 				h := httpReq.Header.Get(HeaderAccessControlRequestHeaders)
 				if h != "" {
-					req.ResponseHeader().Set(HeaderAccessControlAllowHeaders, h)
+					header.Set(HeaderAccessControlAllowHeaders, h)
 				}
 			}
 			if cfg.MaxAge > 0 {
-				req.ResponseHeader().Set(HeaderAccessControlMaxAge, strconv.Itoa(cfg.MaxAge))
+				header.Set(HeaderAccessControlMaxAge, strconv.Itoa(cfg.MaxAge))
 			}
 
 			return nil, nil

--- a/encoder.go
+++ b/encoder.go
@@ -11,14 +11,12 @@ type Encoder interface {
 	Encode(w http.ResponseWriter, obj interface{}) error
 }
 
+// Header is an alias of http.Header for convenient uses.
+type Header = http.Header
+
 type defaultEncoder struct{}
 
 func (d *defaultEncoder) Encode(w http.ResponseWriter, obj interface{}) error {
-	if obj == nil {
-		w.WriteHeader(http.StatusNoContent)
-		return nil
-	}
-
 	enc := json.NewEncoder(w)
 	return enc.Encode(obj)
 }

--- a/request.go
+++ b/request.go
@@ -12,15 +12,12 @@ type Request interface {
 	HTTPRequest() *http.Request
 	// Decode decodes the request to an object.
 	Decode(obj interface{}) error
-	// ResponseHeader returns the header map that will be sent.
-	ResponseHeader() http.Header
 }
 
 type requestImpl struct {
-	decoder    Decoder
-	httpWriter http.ResponseWriter
-	httpReq    *http.Request
-	params     httprouter.Params
+	decoder Decoder
+	httpReq *http.Request
+	params  httprouter.Params
 }
 
 func (r *requestImpl) HTTPRequest() *http.Request {
@@ -37,14 +34,4 @@ func (r *requestImpl) Decode(obj interface{}) error {
 	}
 
 	return r.decoder.Decode(obj, r.httpReq)
-}
-
-func (r *requestImpl) ResponseHeader() http.Header {
-	return r.httpWriter.Header()
-}
-
-func (r *requestImpl) responseError(err error) {
-	r.httpWriter.WriteHeader(http.StatusInternalServerError)
-	// TODO: Add logs here
-	_, _ = r.httpWriter.Write([]byte(err.Error()))
 }


### PR DESCRIPTION
Move ResponseHeader away from Request to separate the concern.
`ResponseHeaderFromCtx` will be used to extract the response header.